### PR TITLE
Reset password

### DIFF
--- a/EDD_AR_Emails.php
+++ b/EDD_AR_Emails.php
@@ -1,0 +1,167 @@
+<?php
+
+class EDD_AR_Emails {
+
+	function __construct() {
+
+		// stop EDD from sending new user notification, we want to customize this a bit
+		remove_action( 'edd_insert_user', 'edd_new_user_notification', 10, 2 );
+
+		// add our new email notifications
+		add_action( 'edd_auto_register_insert_user', array( $this, 'email_notifications' ), 10, 3 );
+
+		// Add new email tags: {set_password_link} and {login_link}
+		add_action( 'edd_add_email_tags', array( $this, 'add_email_tag' ), 100 );
+
+	}
+
+	/**
+	 * Notifications
+	 * Sends the user an email with their logins details and also sends the site admin an email notifying them of a signup
+	 *
+	 * @since 1.1
+	 */
+	public function email_notifications( $user_id = 0, $user_data = array() ) {
+
+		$user = get_userdata( $user_id );
+
+		$user_email_disabled  = edd_get_option( 'edd_auto_register_disable_user_email', '' );
+		$admin_email_disabled = edd_get_option( 'edd_auto_register_disable_admin_email', '' );
+
+		// The blogname option is escaped with esc_html on the way into the database in sanitize_option
+		// we want to reverse this for the plain text arena of emails.
+		$blogname = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+		$message  = sprintf( __( 'New user registration on your site %s:', 'edd-auto-register' ), $blogname ) . "\r\n\r\n";
+		$message .= sprintf( __( 'Username: %s', 'edd-auto-register' ), $user->user_login ) . "\r\n\r\n";
+		$message .= sprintf( __( 'E-mail: %s', 'edd-auto-register' ), $user->user_email ) . "\r\n";
+
+		if ( ! $admin_email_disabled ) {
+			@wp_mail( get_option( 'admin_email' ), sprintf( __( '[%s] New User Registration', 'edd-auto-register' ), $blogname ), $message );
+		}
+
+		// user registration
+		if ( empty( $user_data['user_pass'] || ! $user_email_disabled ) ) {
+			return;
+		}
+
+		// message
+		$message = $this->get_email_body_content( $user, $user_data );
+
+		// subject line
+		$subject = apply_filters( 'edd_auto_register_email_subject', sprintf( __( '[%s] Your username and password', 'edd-auto-register' ), $blogname ) );
+
+		// get from name and email from EDD options
+		$from_name  = edd_get_option( 'from_name', get_bloginfo( 'name' ) );
+		$from_email = edd_get_option( 'from_email', get_bloginfo( 'admin_email' ) );
+
+		$headers = "From: " . stripslashes_deep( html_entity_decode( $from_name, ENT_COMPAT, 'UTF-8' ) ) . " <$from_email>\r\n";
+		$headers .= "Reply-To: ". $from_email . "\r\n";
+		$headers = apply_filters( 'edd_auto_register_headers', $headers );
+
+		$emails = new EDD_Emails;
+
+		$emails->__set( 'from_name', $from_name );
+		$emails->__set( 'from_email', $from_email );
+		$emails->__set( 'headers', $headers );
+
+		// Email the user
+		$emails->send( $user_data['user_email'], $subject, $message );
+
+	}
+
+	/**
+	 * Email Template Body
+	 *
+	 * @since 1.0
+	 * @return string $default_email_body Body of the email
+	 */
+	public function get_email_body_content( $user, $user_data ) {
+		$key = get_password_reset_key( $user );
+
+		// Email body
+		$default_email_body = sprintf( __( 'Dear %s', 'edd-auto-register' ), $user_data['first_name'] ) . ",\n\n";
+		$default_email_body .= __( 'Below are your login details:', 'edd-auto-register' ) . "\n\n";
+		$default_email_body = sprintf( __( 'Your Username: %s', 'edd-auto-register' ), sanitize_user( $user_data['user_login'], true ) ) . "\r\n\r\n";
+		$default_email_body .= __('To set your password, visit the following address:') . "\r\n\r\n";
+		$default_email_body .= network_site_url( 'wp-login.php?action=rp&key=' . $key . '&login=' . rawurlencode( $user_data['user_login'] ), 'login' ) . "\r\n\r\n";
+		$default_email_body .= sprintf( __( 'Login: %s', 'edd-auto-register' ), wp_login_url() ) . "\r\n";
+
+		$default_email_body = apply_filters( 'edd_auto_register_email_body', $default_email_body,  $user_data['first_name'], sanitize_user( $user_data['user_login'], true ), $user_data['user_pass'] );
+
+		return $default_email_body;
+	}
+
+	/**
+	 * Define new tags {set_password_link} and {login_link}
+	 *
+	 * @since 1.4
+	 */
+	public function add_email_tag() {
+
+		edd_add_email_tag(
+			'set_password_link',
+			__( 'The password set link', 'edd-auto-register' ),
+			array( $this, 'reset_password_link_tag' )
+		);
+
+		edd_add_email_tag(
+			'login_link',
+			__( 'The login link', 'edd-auto-register' ),
+			array( $this, 'login_link_tag' )
+		);
+
+	}
+
+	/**
+	 * Check if it the first purchase
+	 *
+	 * @since 1.4
+	 * @return bool If it is the first puchase then return true else false
+	 */
+	public function is_first_purchase() {
+		$user = wp_get_current_user();
+		$customer = new EDD_Customer( $user->ID, true );
+		if( $customer->purchase_count < 2 ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Email tag callback for {set_password_link}
+	 *
+	 * @since 1.4
+	 * @return string Return link to set the password
+	 */
+	public function reset_password_link_tag() {
+
+		if( $this->is_first_purchase() ) {
+			$user = wp_get_current_user();
+			$key = get_password_reset_key( $user );
+			return'<a href="' . network_site_url( 'wp-login.php?action=rp&key=' . $key . '&login=' . rawurlencode( $user->user_login ), 'login' ) . '">' . __( 'Set your password', 'edd-auto-register' ) . '</a>';
+		} else {
+			return;
+		}
+
+	}
+
+	/**
+	 * Email tag callback for {login_link}
+	 *
+	 * @since 1.4
+	 * @return string Return link to set the password
+	 */
+	public function login_link_tag() {
+
+		if( $this->is_first_purchase() ) {
+			return '<a href="' . wp_login_url() . '">' . __( 'Login', 'edd-auto-register' ) . '</a>';
+		} else {
+			return;
+		}
+
+	}
+
+}
+$edd_ar_emails = new EDD_AR_Emails;

--- a/EDD_AR_Emails.php
+++ b/EDD_AR_Emails.php
@@ -119,8 +119,8 @@ class EDD_AR_Emails {
 	 * @since 1.4
 	 * @return bool If it is the first puchase then return true else false
 	 */
-	public function is_first_purchase() {
-		$user = wp_get_current_user();
+	public function is_first_purchase( $payment_id, $tag ) {
+		$user = $this-get_user( $payment_id );
 		$customer = new EDD_Customer( $user->ID, true );
 		if( $customer->purchase_count < 2 ) {
 			return true;
@@ -135,10 +135,10 @@ class EDD_AR_Emails {
 	 * @since 1.4
 	 * @return string Return link to set the password
 	 */
-	public function reset_password_link_tag() {
+	public function reset_password_link_tag( $payment_id, $tag ) {
 
 		if( $this->is_first_purchase() ) {
-			$user = wp_get_current_user();
+			$user = $this-get_user( $payment_id );
 			$key = get_password_reset_key( $user );
 			return'<a href="' . network_site_url( 'wp-login.php?action=rp&key=' . $key . '&login=' . rawurlencode( $user->user_login ), 'login' ) . '">' . __( 'Set your password', 'edd-auto-register' ) . '</a>';
 		} else {
@@ -161,6 +161,21 @@ class EDD_AR_Emails {
 			return;
 		}
 
+	}
+
+	/**
+	 * Fetch user Object
+	 *
+	 * @since 1.4
+	 * @param int $payment_id Payment ID
+	 * @return WP_User|false WP_User object on success, false on failure.
+	 */
+	public function get_user( $payment_id = 0 ) {
+		$user_id = edd_get_payment_user_id( $payment_id );
+		if ( $user_id ) {
+			return get_userdata( $user_id );
+		}
+		return wp_get_current_user();
 	}
 
 }

--- a/backward-compatbility.php
+++ b/backward-compatbility.php
@@ -1,0 +1,81 @@
+<?php
+
+// Included for sites using WP 4.3 or lower
+if ( ! function_exists( 'get_password_reset_key' ) ) {
+	/**
+	 * Creates, stores, then returns a password reset key for user.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @global wpdb         $wpdb      WordPress database abstraction object.
+	 * @global PasswordHash $wp_hasher Portable PHP password hashing framework.
+	 *
+	 * @param WP_User $user User to retrieve password reset key for.
+	 *
+	 * @return string|WP_Error Password reset key on success. WP_Error on error.
+	 */
+	function get_password_reset_key( $user ) {
+		global $wpdb, $wp_hasher;
+
+		/**
+		 * Fires before a new password is retrieved.
+		 *
+		 * @since 1.5.0
+		 * @deprecated 1.5.1 Misspelled. Use 'retrieve_password' hook instead.
+		 *
+		 * @param string $user_login The user login name.
+		 */
+		do_action( 'retreive_password', $user->user_login );
+
+		/**
+		 * Fires before a new password is retrieved.
+		 *
+		 * @since 1.5.1
+		 *
+		 * @param string $user_login The user login name.
+		 */
+		do_action( 'retrieve_password', $user->user_login );
+
+		/**
+		 * Filter whether to allow a password to be reset.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param bool true           Whether to allow the password to be reset. Default true.
+		 * @param int  $user_data->ID The ID of the user attempting to reset a password.
+		 */
+		$allow = apply_filters( 'allow_password_reset', true, $user->ID );
+
+		if ( ! $allow ) {
+			return new WP_Error( 'no_password_reset', __( 'Password reset is not allowed for this user' ) );
+		} elseif ( is_wp_error( $allow ) ) {
+			return $allow;
+		}
+
+		// Generate something random for a password reset key.
+		$key = wp_generate_password( 20, false );
+
+		/**
+		 * Fires when a password reset key is generated.
+		 *
+		 * @since 2.5.0
+		 *
+		 * @param string $user_login The username for the user.
+		 * @param string $key        The generated password reset key.
+		 */
+		do_action( 'retrieve_password_key', $user->user_login, $key );
+
+		// Now insert the key, hashed, into the DB.
+		if ( empty( $wp_hasher ) ) {
+			require_once ABSPATH . WPINC . '/class-phpass.php';
+			$wp_hasher = new PasswordHash( 8, true );
+		}
+		$hashed = time() . ':' . $wp_hasher->HashPassword( $key );
+		$key_saved = $wpdb->update( $wpdb->users, array( 'user_activation_key' => $hashed ), array( 'user_login' => $user->user_login ) );
+		if ( false === $key_saved ) {
+			return new WP_Error( 'no_password_key_update', __( 'Could not save password reset key to database.' ) );
+		}
+
+		return $key;
+	}
+}

--- a/edd-auto-register.php
+++ b/edd-auto-register.php
@@ -18,6 +18,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! defined( 'EDD_AR_PLUGIN_DIR' ) ) {
+	define( 'EDD_AR_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+}
+
 if ( ! class_exists( 'EDD_Auto_Register' ) ) {
 
 	final class EDD_Auto_Register {
@@ -130,12 +134,6 @@ if ( ! class_exists( 'EDD_Auto_Register' ) ) {
 			// create user when purchase is created
 			add_action( 'edd_insert_payment', array( $this, 'maybe_insert_user' ), 10, 2 );
 
-			// stop EDD from sending new user notification, we want to customize this a bit
-			remove_action( 'edd_insert_user', 'edd_new_user_notification', 10, 2 );
-
-			// add our new email notifications
-			add_action( 'edd_auto_register_insert_user', array( $this, 'email_notifications' ), 10, 3 );
-
 			// Ensure registration form is never shown
 			add_filter( 'edd_get_option_show_register_form', array( $this, 'remove_register_form' ), 10, 3 );
 
@@ -181,83 +179,6 @@ if ( ! class_exists( 'EDD_Auto_Register' ) ) {
 				// Load the default language files
 				load_plugin_textdomain( 'edd-auto-register', false, $lang_dir );
 			}
-		}
-
-		/**
-		 * Notifications
-		 * Sends the user an email with their logins details and also sends the site admin an email notifying them of a signup
-		 *
-		 * @since 1.1
-		 */
-		public function email_notifications( $user_id = 0, $user_data = array() ) {
-
-			$user = get_userdata( $user_id );
-
-			$user_email_disabled  = edd_get_option( 'edd_auto_register_disable_user_email', '' );
-			$admin_email_disabled = edd_get_option( 'edd_auto_register_disable_admin_email', '' );
-
-			// The blogname option is escaped with esc_html on the way into the database in sanitize_option
-			// we want to reverse this for the plain text arena of emails.
-			$blogname = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-
-			$message  = sprintf( __( 'New user registration on your site %s:', 'edd-auto-register' ), $blogname ) . "\r\n\r\n";
-			$message .= sprintf( __( 'Username: %s', 'edd-auto-register' ), $user->user_login ) . "\r\n\r\n";
-			$message .= sprintf( __( 'E-mail: %s', 'edd-auto-register' ), $user->user_email ) . "\r\n";
-
-			if ( ! $admin_email_disabled ) {
-				@wp_mail( get_option( 'admin_email' ), sprintf( __( '[%s] New User Registration', 'edd-auto-register' ), $blogname ), $message );
-			}
-
-			// user registration
-			if ( empty( $user_data['user_pass'] || ! $user_email_disabled ) ) {
-				return;
-			}
-
-			// message
-			$message = $this->get_email_body_content( $user, $user_data );
-
-			// subject line
-			$subject = apply_filters( 'edd_auto_register_email_subject', sprintf( __( '[%s] Your username and password', 'edd-auto-register' ), $blogname ) );
-
-			// get from name and email from EDD options
-			$from_name  = edd_get_option( 'from_name', get_bloginfo( 'name' ) );
-			$from_email = edd_get_option( 'from_email', get_bloginfo( 'admin_email' ) );
-
-			$headers = "From: " . stripslashes_deep( html_entity_decode( $from_name, ENT_COMPAT, 'UTF-8' ) ) . " <$from_email>\r\n";
-			$headers .= "Reply-To: ". $from_email . "\r\n";
-			$headers = apply_filters( 'edd_auto_register_headers', $headers );
-
-			$emails = new EDD_Emails;
-
-			$emails->__set( 'from_name', $from_name );
-			$emails->__set( 'from_email', $from_email );
-			$emails->__set( 'headers', $headers );
-
-			// Email the user
-			$emails->send( $user_data['user_email'], $subject, $message );
-
-		}
-
-		/**
-		 * Email Template Body
-		 *
-		 * @since 1.0
-		 * @return string $default_email_body Body of the email
-		 */
-		public function get_email_body_content( $user, $user_data ) {
-			$key = get_password_reset_key( $user );
-
-			// Email body
-			$default_email_body = sprintf( __( 'Dear %s', 'edd-auto-register' ), $user_data['first_name'] ) . ",\n\n";
-			$default_email_body .= __( 'Below are your login details:', 'edd-auto-register' ) . "\n\n";
-			$default_email_body = sprintf( __( 'Your Username: %s', 'edd-auto-register' ), sanitize_user( $user_data['user_login'], true ) ) . "\r\n\r\n";
-			$default_email_body .= __('To set your password, visit the following address:') . "\r\n\r\n";
-			$default_email_body .= network_site_url( 'wp-login.php?action=rp&key=' . $key . '&login=' . rawurlencode( $user_data['user_login'] ), 'login' ) . "\r\n\r\n";
-			$default_email_body .= sprintf( __( 'Login: %s', 'edd-auto-register' ), wp_login_url() ) . "\r\n";
-
-			$default_email_body = apply_filters( 'edd_auto_register_email_body', $default_email_body,  $user_data['first_name'], sanitize_user( $user_data['user_login'], true ), $user_data['user_pass'] );
-
-			return $default_email_body;
 		}
 
 		/**
@@ -470,6 +391,8 @@ if ( ! class_exists( 'EDD_Auto_Register' ) ) {
  * @return object Returns an instance of the EDD_Auto_Register class
  */
 function edd_auto_register() {
+	require_once EDD_AR_PLUGIN_DIR . 'EDD_AR_Emails.php';
+	require_once EDD_AR_PLUGIN_DIR . 'backward-compatbility.php';
 	return EDD_Auto_Register::get_instance();
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -18,6 +18,8 @@ Once activated, EDD Auto Register will create a WordPress user account for your 
 
 Guest checkout is required so the plugin overrides the setting. The registration form is hidden on checkout while the plugin is active.
 
+Adds two email tags {set_password_link} and {login_link} which are only added when it the first purchase.
+
 There are various filters available for developers, see the FAQ tab for more information.
 
 **More add-ons for Easy Digital Downloads**


### PR DESCRIPTION
It is bad practice to send passwords by email so I updated the email to only send the password set link. Copied from [wp_new_user_notification()](https://developer.wordpress.org/reference/functions/wp_new_user_notification/)

Added two new email tags {set_password_link} and {login_link} that only output if it the first purchase.

Fixes #13 
